### PR TITLE
Fix issue #: Adding -r option to the read command

### DIFF
--- a/commit
+++ b/commit
@@ -27,7 +27,7 @@ fi
 
 # Check if the current directory is a Git repository
 if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-    read -p "The current directory is not a Git repository. Would you like to initialize it? (y/n): " initialize
+    read -rp "The current directory is not a Git repository. Would you like to initialize it? (y/n): " initialize
     if [ "$initialize" == "y" ]; then
         git init
     else
@@ -37,7 +37,7 @@ if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
 fi
 
 #Prompt for user input
-read -p "Enter commit message: " message
+read -rp "Enter commit message: " message
 echo
 
 # Validate that the commit message is not empty

--- a/install.sh
+++ b/install.sh
@@ -10,11 +10,11 @@ fi
 
 # Ask if the user will like to enter other details or will like to continue with the system configuration
 
-read -p "Do you want to enter your details(y/n): " detail_choice
+read -rp "Do you want to enter your details(y/n): " detail_choice
 
 if [[ $detail_choice == 'y' || $detail_choice == 'Y' ]]; then
 	# Prompt for Git username
-	read -p "Enter Git username: " username
+	read -rp "Enter Git username: " username
 
 	# Validate that the username is not empty
 	if [[ -z "$username" ]]; then
@@ -23,7 +23,7 @@ if [[ $detail_choice == 'y' || $detail_choice == 'Y' ]]; then
 	fi
 
 	# Prompt for Git email
-	read -p "Enter Git email: " email
+	read -rp "Enter Git email: " email
 
 	# Validate that the email is not empty
 	if [[ -z "$email" ]]; then


### PR DESCRIPTION
Adding the -r option to the read command so it won't interpret backlashes as escape sequences.
i.e read -rp "prompt"

Discovers issue using shellcheck